### PR TITLE
Add stats func reference

### DIFF
--- a/indexsearcher.go
+++ b/indexsearcher.go
@@ -7,5 +7,6 @@ type IndexSearcher interface {
 	Lookup(keys ...string) []interface{}
 	All() []interface{}
 	FieldKey(a interface{}) FieldKey
+	Stats(keys ...string) []Stats
 	_id() string
 }


### PR DESCRIPTION
To allow access to the underlying `Stats()` method