### PR TITLE
Expirers default modified and accessed time when unset.

### DIFF
--- a/ageexpirer.go
+++ b/ageexpirer.go
@@ -27,13 +27,24 @@ func (ae *ageExpirer) IsExpired(a interface{}, now time.Time, stats Stats) bool 
 			return v == ExpireTrue
 		}
 	}
-	if ae.cTime != 0 && now.Sub(stats.Created) > ae.cTime {
+
+	cTime := stats.Created
+	mTime := stats.Modified
+	if mTime.IsZero() {
+		mTime = cTime
+	}
+	aTime := stats.Accessed
+	if aTime.IsZero() {
+		aTime = mTime
+	}
+
+	if ae.cTime != 0 && now.Sub(cTime) > ae.cTime {
 		return true
 	}
-	if ae.aTime != 0 && now.Sub(stats.Accessed) > ae.aTime {
+	if ae.aTime != 0 && now.Sub(aTime) > ae.aTime {
 		return true
 	}
-	if ae.mTime != 0 && now.Sub(stats.Modified) > ae.mTime {
+	if ae.mTime != 0 && now.Sub(mTime) > ae.mTime {
 		return true
 	}
 	return false

--- a/ageexpirer_requireall.go
+++ b/ageexpirer_requireall.go
@@ -22,16 +22,27 @@ func AgeExpirerRequireAll(cTime, mTime, aTime time.Duration, cb ...ExpireFunc) E
 
 // IsExpired implements the necessary function for an Expirer
 func (ae *ageExpirerRequireAll) IsExpired(a interface{}, now time.Time, stats Stats) bool {
+	cTime := stats.Created
+	mTime := stats.Modified
+	if mTime.IsZero() {
+		mTime = cTime
+	}
+	aTime := stats.Accessed
+	if aTime.IsZero() {
+		aTime = mTime
+	}
+
 	expired := true
-	if ae.cTime != 0 && now.Sub(stats.Created) < ae.cTime {
+	if ae.cTime != 0 && now.Sub(cTime) < ae.cTime {
 		expired = false
 	}
-	if ae.aTime != 0 && now.Sub(stats.Accessed) < ae.aTime {
+	if ae.aTime != 0 && now.Sub(aTime) < ae.aTime {
 		expired = false
 	}
-	if ae.mTime != 0 && now.Sub(stats.Modified) < ae.mTime {
+	if ae.mTime != 0 && now.Sub(mTime) < ae.mTime {
 		expired = false
 	}
+
 	for _, cb := range ae.cb {
 		if v := cb(a, now, stats); v == ExpireFalse {
 			expired = false


### PR DESCRIPTION
When checking an item's modified and accessed time, if not set they should default to created and modified times.