### PR TITLE
fix race conds and ticker leaks

### DIFF
--- a/store.go
+++ b/store.go
@@ -357,11 +357,11 @@ func (s *Store) DescendStarting(at interface{}, cb Iterator) {
 func (s *Store) ExpireInterval(interval time.Duration) {
 	s.Lock()
 	defer s.Unlock()
-	s.tickerReset <- true
 	if s.ticker != nil {
 		s.ticker.Stop() // resource leak if you dont do this ?
 	}
 	s.ticker = time.NewTicker(interval)
+	s.tickerReset <- true // do this last to signal the ranging goroucine, after the new ticker is created
 }
 
 // Expire finds all expiring items in the store and deletes them

--- a/store.go
+++ b/store.go
@@ -93,7 +93,9 @@ func (s *Store) Init() {
 			case <-s.ticker.C:
 				s.Expire()
 			case <-s.tickerReset:
-				fmt.Println("OMF - tickerReset")
+				// a new ticker has been issued
+				// this 2nd channel prevents the read on the original ticker from
+				// spinning out for all eternity
 			}
 		}
 	}()

--- a/store.go
+++ b/store.go
@@ -345,7 +345,6 @@ func (s *Store) DescendStarting(at interface{}, cb Iterator) {
 
 // ExpireInterval allows setting of a new auto-expire interval (after the current one ticks)
 func (s *Store) ExpireInterval(interval time.Duration) {
-	fmt.Println("Setting interval to", interval)
 	s.Lock()
 	defer s.Unlock()
 	if s.ticker != nil {


### PR DESCRIPTION
There was an extra race cond in another usvc

And this also addresses the ticker leak without going overboard (adds 1 channel to signal the inital read on the orphaned ticker)