### PR TITLE
Return sizing metadata.

### DIFF
--- a/persist/persister.go
+++ b/persist/persister.go
@@ -18,3 +18,22 @@ type Persister interface {
 	// Remove is called when an indexer is expired or deleted and needs removal from persistent store
 	Remove(id string) error
 }
+
+// MetaLoadFunc is a function which will bulk-load the given indexer into the memdb instance at creation time
+type MetaLoadFunc func(id string, indexer interface{}, meta *Meta)
+
+// MetaPersister is an interface to allow persistent storage with additional metadata
+type MetaPersister interface {
+	Persister
+
+	// MetaSave is called to request persistent save of the indexer with id
+	MetaSave(id string, indexer interface{}) (meta *Meta, err error)
+
+	// MetaLoad is called at create time to load all of the persisted items and call loadFunc with each
+	MetaLoad(loadFunc MetaLoadFunc) error
+}
+
+// Meta contains metadata
+type Meta struct {
+	Size uint64
+}

--- a/simul_test.go
+++ b/simul_test.go
@@ -141,9 +141,9 @@ var (
 func simulatePutHandler(mdb *Store) {
 	a := getRand(aEls, 0.1)
 	x := &X{
-		a: a,
-		b: fmt.Sprintf("b%d", getRand(oEls)),
-		c: fmt.Sprintf("c%d", getRand(oEls)),
+		A: a,
+		B: fmt.Sprintf("b%d", getRand(oEls)),
+		C: fmt.Sprintf("c%d", getRand(oEls)),
 	}
 
 	mdb.Put(x)
@@ -151,7 +151,7 @@ func simulatePutHandler(mdb *Store) {
 		exists[a] = true
 	}
 
-	y := mdb.Get(&X{a: a})
+	y := mdb.Get(&X{A: a})
 
 	if y != x {
 		fmt.Printf("Put:\n%#v\nGot:\n%#v\n", x, y)
@@ -189,7 +189,7 @@ func getPotentialNumber(n int) int {
 func simulateDeleteHandler(mdb *Store) {
 	a := getPotentialNumber(aEls)
 
-	mdb.Delete(&X{a: a})
+	mdb.Delete(&X{A: a})
 }
 
 // Expires keys from the database.
@@ -202,7 +202,7 @@ func simulateExpiryHandler(mdb *Store) {
 // Retrieves a key from the database
 func simulateGetHandler(mdb *Store) {
 	a := getPotentialNumber(aEls)
-	mdb.Get(&X{a: a})
+	mdb.Get(&X{A: a})
 }
 
 // Retrieves a key from the database
@@ -257,8 +257,8 @@ func simulateWalkHandler(mdb *Store) {
 	} else if s == 1 {
 		mdb.Descend(ea)
 	} else if s == 2 {
-		mdb.AscendStarting(&X{a: a}, ea)
+		mdb.AscendStarting(&X{A: a}, ea)
 	} else if s == 3 {
-		mdb.DescendStarting(&X{a: a}, ea)
+		mdb.DescendStarting(&X{A: a}, ea)
 	}
 }

--- a/store.go
+++ b/store.go
@@ -527,7 +527,7 @@ func (s *Store) IndexStats(fields ...string) []*IndexStats {
 	i := 0
 	for key, wraps := range index {
 		var size uint64
-		if s.persister != nil {
+		if _, ok := s.persister.(persist.MetaPersister); ok {
 			for _, wrap := range wraps {
 				size += wrap.stats.Size
 			}

--- a/storer.go
+++ b/storer.go
@@ -19,7 +19,7 @@ type Storer interface {
 	Unique() *Store
 	Reversed(order ...bool) *Store
 
-	Persistent(persister persist.Persister) error
+	Persistent(persister persist.MetaPersister) error
 
 	Get(search interface{}) interface{}
 	Put(item interface{}) (interface{}, error)

--- a/storer.go
+++ b/storer.go
@@ -19,7 +19,7 @@ type Storer interface {
 	Unique() *Store
 	Reversed(order ...bool) *Store
 
-	Persistent(persister persist.MetaPersister) error
+	Persistent(persister persist.Persister) error
 
 	Get(search interface{}) interface{}
 	Put(item interface{}) (interface{}, error)

--- a/wrap.go
+++ b/wrap.go
@@ -15,6 +15,7 @@ type Stats struct {
 	Modified time.Time
 	Reads    uint64
 	Writes   uint64
+	Size     uint64
 	w        *wrap
 }
 
@@ -43,6 +44,7 @@ func (s *Stats) set(from Stats) {
 	s.Modified = from.Modified
 	s.Reads = from.Reads
 	s.Writes = from.Writes
+	s.Size = from.Size
 }
 
 // IsZero returns whether the statistic has an item or not
@@ -52,6 +54,7 @@ func (s *Stats) IsZero() bool {
 
 type wrap struct {
 	sync.Mutex
+
 	storer Storer
 	uid    UID
 	item   interface{}


### PR DESCRIPTION
Add new functions to support returning additional sizing metadata.

Code remains backwards compatible if using the old methods.
