### PR TITLE
apply race cond fix on timerdelay, and lock contentions in expire check

### DIFF
--- a/store.go
+++ b/store.go
@@ -2,6 +2,8 @@
 package memdb
 
 import (
+	"sync/atomic"
+
 	"github.com/google/btree"
 	"github.com/nedscode/memdb/persist"
 
@@ -44,7 +46,7 @@ type Store struct {
 	expiryNotifiers []NotifyFunc
 	accessNotifiers []NotifyFunc
 
-	ticker *time.Ticker
+	tickerDelay int64
 }
 
 // NewStore returns an initialized store for you to use
@@ -73,19 +75,17 @@ func (s *Store) Init() {
 		}
 	}()
 
+	// About 2.6 times per minute, shouldn't hit the same time every minute
+	atomic.StoreInt64(&s.tickerDelay, int64(23272*time.Millisecond))
+
 	go func() {
 		// Give initial callers time to call ExpireInterval before we start the first tick
 		time.Sleep(100 * time.Millisecond)
 
-		// If there's no ticker set, create a default one
-		if s.ticker == nil {
-			// About 2.6 times per minute, shouldn't hit the same time every minute
-			s.Lock()
-			s.ticker = time.NewTicker(23272 * time.Millisecond)
-			s.Unlock()
-		}
+		for {
+			delayTime := atomic.LoadInt64(&s.tickerDelay)
+			time.Sleep(time.Duration(delayTime))
 
-		for range s.ticker.C {
 			s.Expire()
 		}
 	}()
@@ -350,9 +350,7 @@ func (s *Store) DescendStarting(at interface{}, cb Iterator) {
 
 // ExpireInterval allows setting of a new auto-expire interval (after the current one ticks)
 func (s *Store) ExpireInterval(interval time.Duration) {
-	s.Lock()
-	defer s.Unlock()
-	s.ticker = time.NewTicker(interval)
+	atomic.StoreInt64(&s.tickerDelay, int64(interval))
 }
 
 // Expire finds all expiring items in the store and deletes them
@@ -533,9 +531,9 @@ func (s *Store) IndexStats(fields ...string) []*IndexStats {
 			}
 		}
 		keys[i] = &IndexStats{
-			Key: strings.Split(key, "\000"),
+			Key:   strings.Split(key, "\000"),
 			Count: uint64(len(wraps)),
-			Size: size,
+			Size:  size,
 		}
 		i++
 	}
@@ -569,9 +567,11 @@ func (s *Store) findExpired() []*wrap {
 	s.backing.Ascend(func(item btree.Item) bool {
 		if w, ok := item.(*wrap); ok {
 			// TODO - Possible lock contention here if this calls any store functions
+			w.RLock()
 			if s.IsExpired(w.item, now, w.stats) {
 				rm = append(rm, w)
 			}
+			w.RUnlock()
 		}
 		return true
 	})

--- a/wrap.go
+++ b/wrap.go
@@ -53,7 +53,7 @@ func (s *Stats) IsZero() bool {
 }
 
 type wrap struct {
-	sync.Mutex
+	sync.RWMutex
 
 	storer Storer
 	uid    UID


### PR DESCRIPTION
Grabbed master and reworked the other race cond fixes on top.

2 fixes basically 

1) Turning access to the timereDelay into an atomic, and using time.Sleep.  Prevents race cond in reading/writing to the timereDelay which gets adjusted as the code is run.

2) Adding locks around the "isExpired" check in findExpired, whilst ascending the BTree collection of items.  Prevents lock contention (?) as the expriy data is updated on items in a different thread.

### Findings (timing differences when running `go test -simulate -seed 1000` 

- Master = 48.8s
- Apply all the changes from the previous PR = 53.2 (+9.1%)

- Changing timeDelay to atomic  = 49.7s (+1.8%)
- Changing findExpired to use a write lock on the store = 53.0s . !!  (+8.6%)
- Stick to a readLock on the store in findExpired, and use a readLock on the BTree = 50.3s (+3%)

So ... applying the last option, keeping the readlock on the store as per master, and applying a readlock over the btree.  Looks safe to me, as the wrapper stats always try a write lock before updating stats. So - using a WriteLock inside the btree iterator is maybe overkill when a ReadLock will do the job.

## NOTE - timing accuracies

Running several passes, can get pretty big swings in the results.  Have seen the same code have runtimes between 48.8s and 56.7s running the same test, depending what the machine is up to.

