### PR TITLE
feat: upgrade backing btree library to v1.1.3, which uses a generic implementation under the hood; adjust iteration functions to avoid potential nil panics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/nedscode/memdb
 
-go 1.21
+go 1.22
 
 require github.com/google/btree v1.1.3

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/nedscode/memdb
 
-go 1.12
+go 1.21
 
-require github.com/google/btree v1.0.2-0.20210830194833-ac7cc57f11e6
+require github.com/google/btree v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/google/btree v1.0.2-0.20210830194833-ac7cc57f11e6 h1:X4/gMSxnuZM8/GbpchZiAks/TzLUJbasawC9AmWgKZU=
-github.com/google/btree v1.0.2-0.20210830194833-ac7cc57f11e6/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9uaxA=
+github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
+github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=

--- a/store.go
+++ b/store.go
@@ -315,7 +315,8 @@ func (s *Store) In(fields ...string) IndexSearcher {
 func (s *Store) Info(cb InfoIterator) {
 	s.RLock()
 	defer s.RUnlock()
-	traverse(s.backing.AscendRange, nil, nil, s.cbWrap(cb))
+
+	s.backing.Ascend(s.cbWrap(cb))
 }
 
 // Ascend calls provided callback function from start (lowest order) of items until end or iterator function returns
@@ -323,14 +324,16 @@ func (s *Store) Info(cb InfoIterator) {
 func (s *Store) Ascend(cb Iterator) {
 	s.RLock()
 	defer s.RUnlock()
-	traverse(s.backing.AscendRange, nil, nil, s.cbWrap(cb))
+
+	s.backing.Ascend(s.cbWrap(cb))
 }
 
 // AscendStarting calls provided callback function from item equal to at until end or iterator function returns false
 func (s *Store) AscendStarting(at interface{}, cb Iterator) {
 	s.RLock()
 	defer s.RUnlock()
-	traverse(s.backing.AscendRange, &wrap{storer: s, item: at}, nil, s.cbWrap(cb))
+
+	s.backing.AscendGreaterOrEqual(&wrap{storer: s, item: at}, s.cbWrap(cb))
 }
 
 // Descend calls provided callback function from end (highest order) of items until start or iterator function returns
@@ -338,14 +341,16 @@ func (s *Store) AscendStarting(at interface{}, cb Iterator) {
 func (s *Store) Descend(cb Iterator) {
 	s.RLock()
 	defer s.RUnlock()
-	traverse(s.backing.DescendRange, nil, nil, s.cbWrap(cb))
+
+	s.backing.Descend(s.cbWrap(cb))
 }
 
 // DescendStarting calls provided callback function from item equal to at until start or iterator function returns false
 func (s *Store) DescendStarting(at interface{}, cb Iterator) {
 	s.RLock()
 	defer s.RUnlock()
-	traverse(s.backing.DescendRange, &wrap{storer: s, item: at}, nil, s.cbWrap(cb))
+
+	s.backing.DescendLessOrEqual(&wrap{storer: s, item: at}, s.cbWrap(cb))
 }
 
 // ExpireInterval allows setting of a new auto-expire interval (after the current one ticks)
@@ -796,8 +801,4 @@ func (s *Store) cbWrap(cb interface{}) btree.ItemIterator {
 		}
 		return true
 	}
-}
-
-func traverse(traverse func(btree.Item, btree.Item, btree.ItemIterator), a, b btree.Item, iterator btree.ItemIterator) {
-	traverse(a, b, iterator)
 }


### PR DESCRIPTION
**Changes:** 
- updates `github.com/google/btree` upstream dependency to v1.1.3
- fixes incompatibility with `nil` bounds passed to `AscendRange` and `DescendRange` b-tree iteration functions; replace with more specific single bound equivalents in the newer library (prevents runtime panics)
- updates module Go version to 1.22, asserting the newer loop semantics